### PR TITLE
made clink useable for users with unset $DOCKER_HUB_USER

### DIFF
--- a/source_commands
+++ b/source_commands
@@ -167,7 +167,13 @@ command_not_found() {
     cmd="$1"
     verbose_echo "$cmd not found in path; attempting clinkery..."
 
-    for name in "$cmd" "$DOCKER_HUB_USER/$cmd"; do
+    candidates=("$cmd")
+
+    if [ -n $DOCKER_HUB_USER ]; then
+      candidates+=("$DOCKER_HUB_USER/$cmd")
+    fi
+
+    for name in $candidates; do
         if image_exists "$name"; then
             image="$name"
         fi


### PR DESCRIPTION
couldn't use clink anymore. somehow some of the last changes introduced a mandatory **$DOCKER_HUB_USER**. I made it optional again. But it's also just an ugly hack.

the root cause seems that "docker inspect --type image '/ubuntu'" is working.

any clues to fix invocation of 'docker inspect'?
