### PR TITLE
Do not add extraneous things on stdout.

### DIFF
--- a/clink
+++ b/clink
@@ -70,7 +70,7 @@ run_cli() {
         if [ $image = "clink" ]; then
             display_usage && return
         fi
-        echo "Running: $image $@"
+        verbose_echo "Running: $image $@"
         run_source
         command_not_found "$image" "$@"
     esac

--- a/source_commands
+++ b/source_commands
@@ -256,7 +256,6 @@ pick_image() {
 
 command_not_found() {
     cmd="$1"
-    echo "$cmd"
     verbose_echo "$cmd not found in path; attempting clinkery..."
     image=$(pick_image $cmd)
     shift


### PR DESCRIPTION
Use verbose_echo instead. The previous behavior broke
some scripts doing e.g. FOO=$(something_with_clink ...),
because the $FOO variable would then contain extra text.
